### PR TITLE
Reduce memory allocations significantly

### DIFF
--- a/src/main/java/dev/hephaestus/atmosfera/client/sound/AtmosphericSound.java
+++ b/src/main/java/dev/hephaestus/atmosfera/client/sound/AtmosphericSound.java
@@ -15,9 +15,11 @@ public record AtmosphericSound(Identifier id, SoundEvent soundEvent,
                                          ImmutableCollection<AtmosphericSoundModifier> modifiers) {
     public float getVolume(ClientWorld world) {
         float volume = 1F;
+        EnvironmentContext context = ((ClientWorldDuck) world).atmosfera$getEnvironmentContext(this.size, this.shape);
+        if(context == null) return 0;
 
         for (AtmosphericSoundModifier modifier : this.modifiers) {
-            volume *= modifier.getModifier(((ClientWorldDuck) world).atmosfera$getEnvironmentContext(this.size, this.shape));
+            volume *= modifier.getModifier(context);
         }
 
         return volume;

--- a/src/main/java/dev/hephaestus/atmosfera/client/sound/modifiers/implementations/PercentBiomeModifier.java
+++ b/src/main/java/dev/hephaestus/atmosfera/client/sound/modifiers/implementations/PercentBiomeModifier.java
@@ -6,17 +6,16 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.hephaestus.atmosfera.client.sound.modifiers.AtmosphericSoundModifier;
 import dev.hephaestus.atmosfera.world.context.EnvironmentContext;
-import net.fabricmc.fabric.api.tag.TagRegistry;
+import net.fabricmc.fabric.api.tag.TagFactory;
 import net.minecraft.tag.Tag;
-import net.minecraft.tag.TagGroup;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 
-public record PercentBiomeModifier(float min, float max, ImmutableCollection<Biome> biomes, ImmutableCollection<Tag<Biome>> biomeTags, ImmutableCollection<Biome.Category> biomeCategories) implements AtmosphericSoundModifier {
-    public PercentBiomeModifier(float min, float max, ImmutableCollection<Biome> biomes, ImmutableCollection<Tag<Biome>> biomeTags, ImmutableCollection<Biome.Category> biomeCategories) {
+public record PercentBiomeModifier(float min, float max, ImmutableCollection<Biome> biomes, ImmutableCollection<Tag.Identified<Biome>> biomeTags, ImmutableCollection<Biome.Category> biomeCategories) implements AtmosphericSoundModifier {
+    public PercentBiomeModifier(float min, float max, ImmutableCollection<Biome> biomes, ImmutableCollection<Tag.Identified<Biome>> biomeTags, ImmutableCollection<Biome.Category> biomeCategories) {
         ImmutableCollection.Builder<Biome> biomesBuilder = ImmutableList.builder();
 
         // Remove blocks that are already present in tags so that they aren't counted twice
@@ -46,7 +45,7 @@ public record PercentBiomeModifier(float min, float max, ImmutableCollection<Bio
             modifier += context.getBiomePercentage(biome);
         }
 
-        for (Tag<Biome> tag : this.biomeTags) {
+        for (Tag.Identified<Biome> tag : this.biomeTags) {
             modifier += context.getBiomeTagPercentage(tag);
         }
 
@@ -108,12 +107,10 @@ public record PercentBiomeModifier(float min, float max, ImmutableCollection<Bio
                 }
             }
 
-            ImmutableCollection.Builder<Tag<Biome>> tags = ImmutableList.builder();
-
-            TagGroup<Biome> biomeTags = world.getTagManager().getOrCreateTagGroup(Registry.BIOME_KEY);
+            ImmutableCollection.Builder<Tag.Identified<Biome>> tags = ImmutableList.builder();
 
             for (Identifier id : this.biomeTags) {
-                tags.add(TagRegistry.create(id, () -> biomeTags));
+                tags.add(TagFactory.BIOME.create(id));
             }
 
             return new PercentBiomeModifier(this.min, this.max, biomes.build(), tags.build(), this.biomeCategories);

--- a/src/main/java/dev/hephaestus/atmosfera/client/sound/modifiers/implementations/PercentBlockModifier.java
+++ b/src/main/java/dev/hephaestus/atmosfera/client/sound/modifiers/implementations/PercentBlockModifier.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.hephaestus.atmosfera.client.sound.modifiers.AtmosphericSoundModifier;
 import dev.hephaestus.atmosfera.world.context.EnvironmentContext;
-import net.fabricmc.fabric.api.tag.TagRegistry;
+import net.fabricmc.fabric.api.tag.TagFactory;
 import net.minecraft.block.Block;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
@@ -14,8 +14,8 @@ import net.minecraft.util.JsonHelper;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 
-public record PercentBlockModifier(float lowerVolumeSlider, float upperVolumeSlider, float min, float max, ImmutableCollection<Block> blocks, ImmutableCollection<Tag<Block>> blockTags) implements AtmosphericSoundModifier, AtmosphericSoundModifier.Factory {
-    public PercentBlockModifier(float lowerVolumeSlider, float upperVolumeSlider, float min, float max, ImmutableCollection<Block> blocks, ImmutableCollection<Tag<Block>> blockTags) {
+public record PercentBlockModifier(float lowerVolumeSlider, float upperVolumeSlider, float min, float max, ImmutableCollection<Block> blocks, ImmutableCollection<Tag.Identified<Block>> blockTags) implements AtmosphericSoundModifier, AtmosphericSoundModifier.Factory {
+    public PercentBlockModifier(float lowerVolumeSlider, float upperVolumeSlider, float min, float max, ImmutableCollection<Block> blocks, ImmutableCollection<Tag.Identified<Block>> blockTags) {
         ImmutableCollection.Builder<Block> blocksBuilder = ImmutableList.builder();
 
         // Remove blocks that are already present in tags so that they aren't counted twice
@@ -46,7 +46,7 @@ public record PercentBlockModifier(float lowerVolumeSlider, float upperVolumeSli
             modifier += context.getBlockTypePercentage(block);
         }
 
-        for (Tag<Block> tag : this.blockTags) {
+        for (Tag.Identified<Block> tag : this.blockTags) {
             modifier += context.getBlockTagPercentage(tag);
         }
 
@@ -57,14 +57,12 @@ public record PercentBlockModifier(float lowerVolumeSlider, float upperVolumeSli
 
     public static PercentBlockModifier create(JsonObject object) {
         ImmutableCollection.Builder<Block> blocks = ImmutableList.builder();
-        ImmutableCollection.Builder<Tag<Block>> tags = ImmutableList.builder();
+        ImmutableCollection.Builder<Tag.Identified<Block>> tags = ImmutableList.builder();
 
         JsonHelper.getArray(object, "blocks").forEach(block -> {
-
-
             // Registers only the loaded IDs to avoid false triggers.
             if (block.getAsString().startsWith("#")) {
-                tags.add(TagRegistry.block(new Identifier(block.getAsString().substring(1))));
+                tags.add(TagFactory.BLOCK.create(new Identifier(block.getAsString().substring(1))));
             } else {
                 Identifier blockId = new Identifier(block.getAsString());
 

--- a/src/main/java/dev/hephaestus/atmosfera/mixin/MixinClientWorld.java
+++ b/src/main/java/dev/hephaestus/atmosfera/mixin/MixinClientWorld.java
@@ -14,7 +14,9 @@ import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -27,11 +29,11 @@ import java.util.function.Supplier;
 public class MixinClientWorld implements ClientWorldDuck {
     private AtmosphericSoundHandler atmosfera$soundHandler;
     private HashMap<EnvironmentContext.Size, Sphere> atmosfera$environmentContexts;
+    private boolean atmosfera$initialized;
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void initializeSoundHandler(ClientPlayNetworkHandler networkHandler, ClientWorld.Properties properties, RegistryKey<World> registryRef, DimensionType dimensionType, int loadDistance, Supplier<Profiler> profiler, WorldRenderer worldRenderer, boolean debugWorld, long seed, CallbackInfo ci) {
         this.atmosfera$soundHandler = new AtmosphericSoundHandler((ClientWorld) (Object) this);
-        this.atmosfera$environmentContexts = new HashMap<>();
     }
 
     @Inject(method = "tick", at = @At("TAIL"))
@@ -46,26 +48,34 @@ public class MixinClientWorld implements ClientWorldDuck {
 
     @Override
     public EnvironmentContext atmosfera$getEnvironmentContext(EnvironmentContext.Size size, EnvironmentContext.Shape shape) {
+        if(!atmosfera$isEnvironmentContextInitialized()) return null;
         return switch (shape) {
-            case UPPER_HEMISPHERE -> this.atmosfera$environmentContexts.computeIfAbsent(size, Sphere::new).getUpperHemisphere();
-            case LOWER_HEMISPHERE -> this.atmosfera$environmentContexts.computeIfAbsent(size, Sphere::new).getLowerHemisphere();
+            case UPPER_HEMISPHERE -> this.atmosfera$environmentContexts.get(size).getUpperHemisphere();
+            case LOWER_HEMISPHERE -> this.atmosfera$environmentContexts.get(size).getLowerHemisphere();
             case SPHERE -> this.atmosfera$environmentContexts.get(size);
         };
     }
 
     @Override
     public void atmosfera$updateEnvironmentContext() {
-        ClientPlayerEntity player = MinecraftClient.getInstance().player;
-
-        if (player != null && ContextUtil.TASK_QUEUE.isEmpty()) {
-            this.atmosfera$environmentContexts.computeIfAbsent(EnvironmentContext.Size.SMALL, Sphere::new).update(player);
-            this.atmosfera$environmentContexts.computeIfAbsent(EnvironmentContext.Size.MEDIUM, Sphere::new).update(player);
-            this.atmosfera$environmentContexts.computeIfAbsent(EnvironmentContext.Size.LARGE, Sphere::new).update(player);
+        if(!this.atmosfera$initialized) {
+            ClientPlayerEntity player = MinecraftClient.getInstance().player;
+            this.atmosfera$environmentContexts = new HashMap<>();
+            this.atmosfera$environmentContexts.put(EnvironmentContext.Size.SMALL, new Sphere(EnvironmentContext.Size.SMALL, player));
+            this.atmosfera$environmentContexts.put(EnvironmentContext.Size.MEDIUM, new Sphere(EnvironmentContext.Size.MEDIUM, player));
+            this.atmosfera$environmentContexts.put(EnvironmentContext.Size.LARGE, new Sphere(EnvironmentContext.Size.LARGE, player));
+            // set initialized last to prevent race condition for filling the hash map
+            atmosfera$initialized = true;
+        }
+        if (ContextUtil.TASK_QUEUE.isEmpty()) {
+            this.atmosfera$environmentContexts.get(EnvironmentContext.Size.SMALL).update();
+            this.atmosfera$environmentContexts.get(EnvironmentContext.Size.MEDIUM).update();
+            this.atmosfera$environmentContexts.get(EnvironmentContext.Size.LARGE).update();
         }
     }
 
     @Override
     public boolean atmosfera$isEnvironmentContextInitialized() {
-        return !this.atmosfera$environmentContexts.isEmpty() && this.atmosfera$environmentContexts.get(EnvironmentContext.Size.SMALL).getPlayer() != null;
+        return atmosfera$initialized;
     }
 }

--- a/src/main/java/dev/hephaestus/atmosfera/world/context/AbstractEnvironmentContext.java
+++ b/src/main/java/dev/hephaestus/atmosfera/world/context/AbstractEnvironmentContext.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 abstract class AbstractEnvironmentContext implements EnvironmentContext {
-    ClientPlayerEntity player;
+    final ClientPlayerEntity player;
     int altitude = 0;
     int elevation = -1;
     boolean isDay = false;
@@ -15,6 +15,10 @@ abstract class AbstractEnvironmentContext implements EnvironmentContext {
     boolean isStormy = false;
     @Nullable Entity vehicle = null;
     Collection<String> bossBars;
+
+    protected AbstractEnvironmentContext(ClientPlayerEntity player) {
+        this.player = player;
+    }
 
     @Override
     public float getAltitude() {
@@ -54,16 +58,5 @@ abstract class AbstractEnvironmentContext implements EnvironmentContext {
     @Override
     public Collection<String> getBossBars() {
         return this.bossBars;
-    }
-
-    void copy(AbstractEnvironmentContext context) {
-        this.player = context.player;
-        this.altitude = context.altitude;
-        this.elevation = context.elevation;
-        this.isDay = context.isDay;
-        this.isRainy = context.isRainy;
-        this.isStormy = context.isStormy;
-        this.vehicle = context.vehicle;
-        this.bossBars = context.bossBars;
     }
 }

--- a/src/main/java/dev/hephaestus/atmosfera/world/context/EnvironmentContext.java
+++ b/src/main/java/dev/hephaestus/atmosfera/world/context/EnvironmentContext.java
@@ -13,11 +13,11 @@ public interface EnvironmentContext {
 
     float getBlockTypePercentage(Block block);
 
-    float getBlockTagPercentage(Tag<Block> blocks);
+    float getBlockTagPercentage(Tag.Identified<Block> blocks);
 
     float getBiomePercentage(Biome biome);
 
-    float getBiomeTagPercentage(Tag<Biome> biomes);
+    float getBiomeTagPercentage(Tag.Identified<Biome> biomes);
 
     float getBiomeCategoryPercentage(Biome.Category biomes);
 


### PR DESCRIPTION
Reduced dynamic memory allocation in `Hemisphere.add` and other places by ~50 MB/s (~90%).

Improvements:
* Prevent allocating thousands of new `TagDelegate`s each update by using `Identifier` as map keys.
* Prevent allocating many new `ConcurrentHashMap$Node` each update by using `replaceAll((block, count) -> 0)` instead of `clear()`
* Replaced deprecated `TagRegistry.block` and `TagRegistry.create` with `TagFactory`
* Replaced `atmosfera$environmentContexts.computeIfAbsent` with one time map initialization

Using `ConcurrentHashMapreplaceAll()` instead of `clear()` will keep all created Nodes around forever, but I don't think that'll be an issue since there are very few and they need little memory.

I've tested this somewhat, `blockTags` do seem to work but maybe I am missing something since I am not sure why the code was using `TagDelegate`s in the first place. Also I did not find any use of `biomeTags` so I could not test it.